### PR TITLE
chore: DRY for the Lumigo endpoint

### DIFF
--- a/src/container-stack.ts
+++ b/src/container-stack.ts
@@ -9,6 +9,7 @@ import { IQueue } from 'aws-cdk-lib/aws-sqs';
 import { Construct } from 'constructs';
 
 export interface ContainerStackProps extends StackProps {
+  readonly lumigoEndpoint: URL;
   readonly queue: IQueue;
 }
 
@@ -50,7 +51,7 @@ export class MyContainerStack extends Stack {
         }),
         environment: {
           AUTOWRAPT_BOOTSTRAP: 'lumigo_opentelemetry', // Activate the Lumigo instrumentation!
-          LUMIGO_ENDPOINT: 'https://angels-edge-app-us-west-2.angels.golumigo.com/v1/traces',
+          LUMIGO_ENDPOINT: props.lumigoEndpoint.toString(),
           TARGET_QUEUE_URL: props.queue.queueUrl!,
           OTEL_SERVICE_NAME: 'lumigo-container-demo', // This will be the service name in Lumigo
         },

--- a/src/lambda-stack.ts
+++ b/src/lambda-stack.ts
@@ -6,11 +6,15 @@ import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Queue, QueueEncryption } from 'aws-cdk-lib/aws-sqs';
 import { Construct } from 'constructs';
 
+export interface LambdaStackProps extends StackProps {
+  readonly lumigoEndpoint: URL;
+}
+
 export class MyLambdaStack extends Stack {
   public readonly api: RestApi;
   public readonly queue: Queue;
 
-  constructor(scope: Construct, id: string, props: StackProps = {}) {
+  constructor(scope: Construct, id: string, props: LambdaStackProps) {
     super(scope, id, props);
 
     this.queue = new Queue(this, 'LumigoDemoQueue', {
@@ -20,7 +24,7 @@ export class MyLambdaStack extends Stack {
     const handler = new NodejsFunction(this, 'TestLambda', {
       environment: {
         LUMIGO_TRACER_TOKEN: SecretValue.secretsManager('AccessKeys', { jsonField: 'LumigoToken' }).toString(), // Pity we cannot mount secrets in the same way ECS can :-(
-        LUMIGO_TRACER_HOST: 'angels-edge-app-us-west-2.angels.golumigo.com',
+        LUMIGO_TRACER_HOST: props.lumigoEndpoint.hostname,
         AWS_LAMBDA_EXEC_WRAPPER: '/opt/lumigo_wrapper',
       },
       layers: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { URL } from 'node:url';
 import { App } from 'aws-cdk-lib';
 
 import { MyContainerStack } from './container-stack';
@@ -11,13 +12,17 @@ const stackEnvironment = {
   region: process.env.CDK_DEFAULT_REGION,
 };
 
+const lumigoEndpoint = new URL('https://angels-edge-app-us-west-2.angels.golumigo.com');
+
 const lambdaStack = new MyLambdaStack(app, 'lumigo-webinar-lambda', {
   env: stackEnvironment,
+  lumigoEndpoint: lumigoEndpoint,
 });
 
 new MyContainerStack(app, 'lumigo-webinar-container', {
   env: stackEnvironment,
   queue: lambdaStack.queue,
+  lumigoEndpoint: new URL('v1/traces', lumigoEndpoint.toString()),
 });
 
 app.synth();


### PR DESCRIPTION
Use types StackProps to pass the LumigoEndpoint while specifying it once in `main.ts`.